### PR TITLE
Update Kotlin and Android Gradle plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'at.resiverbindet.activityrecognition'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.1.51'
+    ext.kotlin_version = '1.3.21'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Otherwise one gets complaints like this when using newer versions:
```
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.2.51 and higher. Project 'activity_recognition' is using version 1.1.51.
```